### PR TITLE
Build both .dep and .rpm packages

### DIFF
--- a/Office365/package.json
+++ b/Office365/package.json
@@ -38,7 +38,14 @@
       "desktop": {
         "StartupWMClass": "Outlook for Office 365 Desktop Application"
       },
-      "target": "deb"
+      "target": [
+        {
+          "target": "deb"
+        },
+        {
+          "target": "rpm"
+        }
+      ]
     },
     "win": {
       "target":"msi"

--- a/Outlook.com/package.json
+++ b/Outlook.com/package.json
@@ -38,7 +38,14 @@
       "desktop": {
         "StartupWMClass": "Outlook for Outlook.com Desktop Application"
       },
-      "target": "deb"
+      "target": [
+        {
+          "target": "deb"
+        },
+        {
+          "target": "rpm"
+        }
+      ]
     },
     "win": {
       "target":"msi"


### PR DESCRIPTION
Your great electron app also works on Fedora.
This MR builds both `.deb` and `.rpm` packages.